### PR TITLE
Add Front-Commerce description to the partners page

### DIFF
--- a/partners/storefronts.html
+++ b/partners/storefronts.html
@@ -36,14 +36,44 @@ First one gets listed top.
 This may change at a later point.
 -->
 <section class="boxed-content">
-    <h4>Front Commerce</h4>
+  <h4>Front-Commerce</h4>
 
-    <p>
-        Craft delightful e-commerce experiences using modern web technologies #React #GraphQL #PWA #microservice
-        (src <a href="https://twitter.com/Front_Commerce">Twitter</a>)
-    </p>
+  <p>
+    Front-Commerce® is an advanced StoreFront solution developed in France with
+    a full support of OpenMage. Ready to use, it allows existing or new store to
+    become a <abbr title="Progressive Web Application">PWA</abbr> and take
+    benefits from <abbr title="Single Page Application">SPA</abbr> architecture.
+    This will concretely brings astonishing speed to boost sales, while keeping
+    SEO on high standards (thanks to
+    <abbr title="Server Side Rendering">SSR</abbr>).
+  </p>
 
-    <a href="https://www.front-commerce.com/">https://www.front-commerce.com/</a>
+  <p>
+    Front-Commerce has been designed by developers, bringing them total freedom
+    on UI and decoupling the front-end from Magento templating system. The stack
+    brings React, Node and GraphQL, with the latest tools and standards for code
+    quality and maintenance best practices such as unit tests and Design System.
+    With a micro-services architecture, merging content and data from diverse
+    sources in real time is simpler than old-school synchronizations through
+    flat files.
+  </p>
+
+  <p>
+    Thanks to the commercial licence you get real time corrective support and
+    the promise of an up-to-date Javascript stack, relieving developers of this
+    complex task.
+  </p>
+
+  <p>
+    Front-Commerce has been in production since early 2018 and is also
+    compatible with Magento 2. They are targeting openings to other platforms
+    according to customer requests.
+  </p>
+
+  <p>
+    <a href="https://www.front-commerce.com/"
+      >https://www.front-commerce.com/</a
+    >
+    (<a href="https://twitter.com/Front_Commerce">@Front_Commerce</a>)
+  </p>
 </section>
-
-


### PR DESCRIPTION
Hi!

Here is our first try. Let me know if you think we should rephrase parts, make it shorter or add a logo.

BTW first projects on OpenMage are starting in May :muscle: and we are accepting other early adopters, hence the « _full support of OpenMage_ » part (even though we are still busy at it).