### PR TITLE
point Blog link to actuall Blog Page

### DIFF
--- a/index.md
+++ b/index.md
@@ -145,7 +145,7 @@ redirect_from: "/magento-lts/"
                     Support PHP 7.4 as they are still in the Review, but they should be ready with the next release.
                 </div>
                 <div class="roadmap__steps-more">
-                    <a class="roadmap__steps-link" href="#">read more on our blog</a>
+                    <a class="roadmap__steps-link" href="/blog.html">read more on our blog</a>
                 </div>
             </div>
 
@@ -172,7 +172,7 @@ redirect_from: "/magento-lts/"
                     Continue to build out a full test suite for OpenMage LTS.
                 </div>
                 <div class="roadmap__steps-more">
-                    <a class="roadmap__steps-link" href="#">read more on our blog</a>
+                    <a class="roadmap__steps-link" href="/blog.html">read more on our blog</a>
                 </div>
             </div>
 


### PR DESCRIPTION
On the index Page, there are two links to Blog, but both actually just go to # instead of /blog.html, so I changed them to blog.html