### PR TITLE
Update composer install instructions

### DIFF
--- a/magento-lts/install.html
+++ b/magento-lts/install.html
@@ -73,11 +73,23 @@ title_thin: OpenMage LTS
         "openmage/magento-lts": "{{ site.data.versions.composer.latestStableBranch }}"
     },
     "extra": {
+        "enable-patching": true,
         "magento-core-package-type": "magento-source",
         "magento-root-dir": "htdocs"
     }
 }</code></pre>
                 </div>
+                
+                <p class="install-instructions__warning">
+                    <strong>Warning</strong>
+                    Note: If you are using PHP 7, you should use <code>"aydin-hassan/magento-core-composer-installer": ">=1.0.0 <2.1.0"</code>
+                    as newer versions are compatible with PHP 8 only.
+                </p>
+                <p class="install-instructions__warning">
+                    <strong>Warning</strong>
+                    Note: Starting with magento-lts versions 19.5.X and 20.0.X you must set <code>"enable-patching": true</code> to 
+                    ensure all security patches are applied.
+                </p>
             </div>
         
             <div class="install-instructions__item col-lg-10 offset-lg-1 col-xl-6 offset-xl-0">

--- a/magento-lts/install.html
+++ b/magento-lts/install.html
@@ -69,7 +69,7 @@ title_thin: OpenMage LTS
                 <div class="install-instructions__code">
 <pre><code>{
     "require": {
-        "aydin-hassan/magento-core-composer-installer": "*",
+        "aydin-hassan/magento-core-composer-installer": "^2.1.0",
         "openmage/magento-lts": "{{ site.data.versions.composer.latestStableBranch }}"
     },
     "extra": {
@@ -82,12 +82,12 @@ title_thin: OpenMage LTS
                 
                 <p class="install-instructions__warning">
                     <strong>Warning</strong>
-                    Note: If you are using PHP 7, you should use <code>"aydin-hassan/magento-core-composer-installer": ">=1.0.0 <2.1.0"</code>
+                    Note: If you are using PHP 7, you should use <code>"aydin-hassan/magento-core-composer-installer": "~2.0.0"</code>
                     as newer versions are compatible with PHP 8 only.
                 </p>
                 <p class="install-instructions__warning">
                     <strong>Warning</strong>
-                    Note: Starting with magento-lts versions 19.5.X and 20.0.X you must set <code>"enable-patching": true</code> to 
+                    Note: Starting with magento-lts versions 19.5.0 and 20.1.0 you must set <code>"enable-patching": true</code> to 
                     ensure all security patches are applied.
                 </p>
             </div>


### PR DESCRIPTION
Draft PR for now until we know the next releases' version numbers.

Two updates:
1) `aydin-hassan/magento-core-composer-installer: 2.1.0` is PHP 8 only. So if you're not on PHP 8, you cannot use `*`.
2) `cweagans/composer-patches` will not apply patches to zf1-future unless you explicitly allow it in your composer.json.

Point 2 is actually a pretty big deal, and users who upgrade need to know about this. Otherwise the patches will not be installed and it opens up vulns that were previously fixed.

Note: I did not update the German page.